### PR TITLE
Add fields flag to filter displayable content.

### DIFF
--- a/commands/args.go
+++ b/commands/args.go
@@ -10,6 +10,7 @@ const (
 	CustomerIDArg     = "customer"
 	DescriptionArg    = "description"
 	EmbedArg          = "embed"
+	FieldsArg         = "fields"
 	FromArg           = "from"
 	IDArg             = "id"
 	IncludeArg        = "include"

--- a/commands/displayers/helpers.go
+++ b/commands/displayers/helpers.go
@@ -13,6 +13,30 @@ const (
 	noAppFee          = "none"
 )
 
+func fallbackSafeLocale(loc mollie.Locale) string {
+	if loc == mollie.Locale("") {
+		return ""
+	}
+
+	return string(loc)
+}
+
+func fallbackSafeMode(mode mollie.Mode) string {
+	if mode == mollie.Mode("") {
+		return ""
+	}
+
+	return string(mode)
+}
+
+func fallbackSafeSequence(seq mollie.SequenceType) string {
+	if seq == mollie.SequenceType("") {
+		return ""
+	}
+
+	return string(seq)
+}
+
 func fallbackSafeDate(t *time.Time) string {
 	if t == nil {
 		return noDateContent

--- a/commands/displayers/helpers.go
+++ b/commands/displayers/helpers.go
@@ -1,0 +1,55 @@
+package displayers
+
+import (
+	"strings"
+	"time"
+
+	"github.com/VictorAvelar/mollie-api-go/v2/mollie"
+)
+
+const (
+	displayDateFormat = "02-01-2006"
+	noDateContent     = "----------"
+	noAppFee          = "none"
+)
+
+func fallbackSafeDate(t *time.Time) string {
+	if t == nil {
+		return noDateContent
+	}
+
+	return t.Format(displayDateFormat)
+}
+
+func fallbackSafeAmount(a *mollie.Amount) string {
+	if a == nil {
+		return "--- ---"
+	}
+
+	return stringCombinator(" ", a.Value, a.Currency)
+}
+
+func fallbackSafePaymentMethod(pm mollie.PaymentMethod) string {
+	if pm == mollie.PaymentMethod("") {
+		return "none"
+	}
+
+	return string(pm)
+}
+
+func fallbackSafeAppFee(af *mollie.ApplicationFee) string {
+	if af == nil {
+		return noAppFee
+	}
+
+	return fallbackSafeAmount(af.Amount)
+}
+
+func stringCombinator(s string, parts ...string) string {
+	for i, v := range parts {
+		if v == "" {
+			parts[i] = "-"
+		}
+	}
+	return strings.Join(parts, s)
+}

--- a/commands/displayers/helpers_test.go
+++ b/commands/displayers/helpers_test.go
@@ -1,0 +1,1 @@
+package displayers

--- a/commands/displayers/methods.go
+++ b/commands/displayers/methods.go
@@ -1,8 +1,6 @@
 package displayers
 
 import (
-	"strings"
-
 	"github.com/VictorAvelar/mollie-api-go/v2/mollie"
 )
 
@@ -64,13 +62,4 @@ func safeDisplayableAmount(a *mollie.Amount) *mollie.Amount {
 	}
 
 	return a
-}
-
-func stringCombinator(sep string, vals ...string) string {
-	for i, v := range vals {
-		if v == "" {
-			vals[i] = "-"
-		}
-	}
-	return strings.Join(vals, sep)
 }

--- a/commands/displayers/payments.go
+++ b/commands/displayers/payments.go
@@ -14,37 +14,7 @@ func (lp *MollieListPayments) KV() []map[string]interface{} {
 	var out []map[string]interface{}
 
 	for _, p := range lp.Embedded.Payments {
-		x := map[string]interface{}{
-			"RESOURCE":        p.Resource,
-			"ID":              p.ID,
-			"MODE":            p.Mode,
-			"STATUS":          p.Status,
-			"CANCELABLE":      p.IsCancellable,
-			"AMOUNT":          fallbackSafeAmount(p.Amount),
-			"METHOD":          fallbackSafePaymentMethod(p.Method),
-			"DESCRIPTION":     p.Description,
-			"SEQUENCE":        p.SequenceType,
-			"REMAINING":       fallbackSafeAmount(p.AmountRemaining),
-			"REFUNDED":        fallbackSafeAmount(p.AmountRefunded),
-			"CAPTURED":        fallbackSafeAmount(p.AmountCaptured),
-			"SETTLEMENT":      fallbackSafeAmount(p.SettlementAmount),
-			"APP FEE":         fallbackSafeAppFee(p.ApplicationFee),
-			"CREATED AT":      fallbackSafeDate(p.CreatedAt),
-			"AUTHORIZED AT":   fallbackSafeDate(p.AuthorizedAt),
-			"EXPIRES":         fallbackSafeDate(p.ExpiresAt),
-			"PAID AT":         fallbackSafeDate(p.PaidAt),
-			"FAILED AT":       fallbackSafeDate(p.FailedAt),
-			"CANCELED AT":     fallbackSafeDate(p.CanceledAt),
-			"CUSTOMER ID":     p.CustomerID,
-			"SETTLEMENT ID":   p.SettlementID,
-			"MANDATE ID":      p.MandateID,
-			"SUBSCRIPTION ID": p.SubscriptionID,
-			"ORDER ID":        p.OrderID,
-			"REDIRECT":        p.RedirectURL,
-			"WEBHOOK":         p.WebhookURL,
-			"LOCALE":          p.Locale,
-			"COUNTRY":         p.CountryCode,
-		}
+		x := buildXPayment(&p)
 
 		out = append(out, x)
 	}
@@ -60,16 +30,22 @@ type MolliePayment struct {
 // KV is a displayable group of key value
 func (p *MolliePayment) KV() []map[string]interface{} {
 	var out []map[string]interface{}
-	x := map[string]interface{}{
+	x := buildXPayment(p.Payment)
+	out = append(out, x)
+	return out
+}
+
+func buildXPayment(p *mollie.Payment) map[string]interface{} {
+	return map[string]interface{}{
 		"RESOURCE":        p.Resource,
 		"ID":              p.ID,
-		"MODE":            p.Mode,
+		"MODE":            fallbackSafeMode(p.Mode),
 		"STATUS":          p.Status,
 		"CANCELABLE":      p.IsCancellable,
 		"AMOUNT":          fallbackSafeAmount(p.Amount),
 		"METHOD":          fallbackSafePaymentMethod(p.Method),
 		"DESCRIPTION":     p.Description,
-		"SEQUENCE":        p.SequenceType,
+		"SEQUENCE":        fallbackSafeSequence(p.SequenceType),
 		"REMAINING":       fallbackSafeAmount(p.AmountRemaining),
 		"REFUNDED":        fallbackSafeAmount(p.AmountRefunded),
 		"CAPTURED":        fallbackSafeAmount(p.AmountCaptured),
@@ -88,11 +64,9 @@ func (p *MolliePayment) KV() []map[string]interface{} {
 		"ORDER ID":        p.OrderID,
 		"REDIRECT":        p.RedirectURL,
 		"WEBHOOK":         p.WebhookURL,
-		"LOCALE":          p.Locale,
+		"LOCALE":          fallbackSafeLocale(p.Locale),
 		"COUNTRY":         p.CountryCode,
 	}
-	out = append(out, x)
-	return out
 }
 
 func getSafeExpiration(p mollie.Payment) string {

--- a/commands/displayers/payments.go
+++ b/commands/displayers/payments.go
@@ -14,19 +14,36 @@ func (lp *MollieListPayments) KV() []map[string]interface{} {
 	var out []map[string]interface{}
 
 	for _, p := range lp.Embedded.Payments {
-		ped := getSafeExpiration(p)
-		m := getSafePaymentMethod(p)
-
 		x := map[string]interface{}{
-			"ID":          p.ID,
-			"Mode":        p.Mode,
-			"Status":      p.Status,
-			"Created":     p.CreatedAt.Format("02-01-2006"),
-			"Expires":     ped,
-			"Cancelable":  p.IsCancellable,
-			"Amount":      p.Amount.Value + " " + p.Amount.Currency,
-			"Method":      m,
-			"Description": p.Description,
+			"RESOURCE":        p.Resource,
+			"ID":              p.ID,
+			"MODE":            p.Mode,
+			"STATUS":          p.Status,
+			"CANCELABLE":      p.IsCancellable,
+			"AMOUNT":          fallbackSafeAmount(p.Amount),
+			"METHOD":          fallbackSafePaymentMethod(p.Method),
+			"DESCRIPTION":     p.Description,
+			"SEQUENCE":        p.SequenceType,
+			"REMAINING":       fallbackSafeAmount(p.AmountRemaining),
+			"REFUNDED":        fallbackSafeAmount(p.AmountRefunded),
+			"CAPTURED":        fallbackSafeAmount(p.AmountCaptured),
+			"SETTLEMENT":      fallbackSafeAmount(p.SettlementAmount),
+			"APP FEE":         fallbackSafeAppFee(p.ApplicationFee),
+			"CREATED AT":      fallbackSafeDate(p.CreatedAt),
+			"AUTHORIZED AT":   fallbackSafeDate(p.AuthorizedAt),
+			"EXPIRES":         fallbackSafeDate(p.ExpiresAt),
+			"PAID AT":         fallbackSafeDate(p.PaidAt),
+			"FAILED AT":       fallbackSafeDate(p.FailedAt),
+			"CANCELED AT":     fallbackSafeDate(p.CanceledAt),
+			"CUSTOMER ID":     p.CustomerID,
+			"SETTLEMENT ID":   p.SettlementID,
+			"MANDATE ID":      p.MandateID,
+			"SUBSCRIPTION ID": p.SubscriptionID,
+			"ORDER ID":        p.OrderID,
+			"REDIRECT":        p.RedirectURL,
+			"WEBHOOK":         p.WebhookURL,
+			"LOCALE":          p.Locale,
+			"COUNTRY":         p.CountryCode,
 		}
 
 		out = append(out, x)
@@ -43,18 +60,36 @@ type MolliePayment struct {
 // KV is a displayable group of key value
 func (p *MolliePayment) KV() []map[string]interface{} {
 	var out []map[string]interface{}
-	ped := getSafeExpiration(*p.Payment)
-	m := getSafePaymentMethod(*p.Payment)
 	x := map[string]interface{}{
-		"ID":          p.ID,
-		"Mode":        p.Mode,
-		"Status":      p.Status,
-		"Created":     p.CreatedAt.Format("02-01-2006"),
-		"Expires":     ped,
-		"Cancelable":  p.IsCancellable,
-		"Amount":      p.Amount.Value + " " + p.Amount.Currency,
-		"Method":      m,
-		"Description": p.Description,
+		"RESOURCE":        p.Resource,
+		"ID":              p.ID,
+		"MODE":            p.Mode,
+		"STATUS":          p.Status,
+		"CANCELABLE":      p.IsCancellable,
+		"AMOUNT":          fallbackSafeAmount(p.Amount),
+		"METHOD":          fallbackSafePaymentMethod(p.Method),
+		"DESCRIPTION":     p.Description,
+		"SEQUENCE":        p.SequenceType,
+		"REMAINING":       fallbackSafeAmount(p.AmountRemaining),
+		"REFUNDED":        fallbackSafeAmount(p.AmountRefunded),
+		"CAPTURED":        fallbackSafeAmount(p.AmountCaptured),
+		"SETTLEMENT":      fallbackSafeAmount(p.SettlementAmount),
+		"APP FEE":         fallbackSafeAppFee(p.ApplicationFee),
+		"CREATED AT":      fallbackSafeDate(p.CreatedAt),
+		"AUTHORIZED AT":   fallbackSafeDate(p.AuthorizedAt),
+		"EXPIRES":         fallbackSafeDate(p.ExpiresAt),
+		"PAID AT":         fallbackSafeDate(p.PaidAt),
+		"FAILED AT":       fallbackSafeDate(p.FailedAt),
+		"CANCELED AT":     fallbackSafeDate(p.CanceledAt),
+		"CUSTOMER ID":     p.CustomerID,
+		"SETTLEMENT ID":   p.SettlementID,
+		"MANDATE ID":      p.MandateID,
+		"SUBSCRIPTION ID": p.SubscriptionID,
+		"ORDER ID":        p.OrderID,
+		"REDIRECT":        p.RedirectURL,
+		"WEBHOOK":         p.WebhookURL,
+		"LOCALE":          p.Locale,
+		"COUNTRY":         p.CountryCode,
 	}
 	out = append(out, x)
 	return out

--- a/commands/displayers/payments_test.go
+++ b/commands/displayers/payments_test.go
@@ -25,19 +25,40 @@ func TestMolliePayment_KV(t *testing.T) {
 			Amount:        &mollie.Amount{Currency: "EUR", Value: "1.00"},
 			Method:        mollie.PayPal,
 			Description:   "testing KV",
+			Locale:        mollie.Locale(""),
 		},
 	}
 
 	w := map[string]interface{}{
-		"ID":          "tr_test",
-		"Mode":        mollie.TestMode,
-		"Status":      "paid",
-		"Created":     n.Format("02-01-2006"),
-		"Expires":     n.AddDate(0, 0, 2).Format("02-01-2006"),
-		"Cancelable":  false,
-		"Amount":      "1.00 EUR",
-		"Method":      "paypal",
-		"Description": "testing KV",
+		"AMOUNT":          "1.00 EUR",
+		"APP FEE":         "none",
+		"AUTHORIZED AT":   "----------",
+		"CANCELABLE":      false,
+		"CANCELED AT":     "----------",
+		"CAPTURED":        "--- ---",
+		"COUNTRY":         "",
+		"CREATED AT":      "04-11-2020",
+		"CUSTOMER ID":     "",
+		"DESCRIPTION":     "testing KV",
+		"EXPIRES":         "06-11-2020",
+		"FAILED AT":       "----------",
+		"ID":              "tr_test",
+		"LOCALE":          "",
+		"MANDATE ID":      "",
+		"METHOD":          "paypal",
+		"MODE":            "test",
+		"ORDER ID":        "",
+		"PAID AT":         "----------",
+		"REDIRECT":        "",
+		"REFUNDED":        "--- ---",
+		"REMAINING":       "--- ---",
+		"RESOURCE":        "",
+		"SEQUENCE":        "",
+		"SETTLEMENT":      "--- ---",
+		"SETTLEMENT ID":   "",
+		"STATUS":          "paid",
+		"SUBSCRIPTION ID": "",
+		"WEBHOOK":         "",
 	}
 
 	want := []map[string]interface{}{}
@@ -94,29 +115,9 @@ func TestMollieListPayments_KV(t *testing.T) {
 		},
 	}
 
-	w := map[string]interface{}{
-		"ID":          "tr_test",
-		"Mode":        mollie.TestMode,
-		"Status":      "paid",
-		"Created":     n.Format("02-01-2006"),
-		"Expires":     n.AddDate(0, 0, 2).Format("02-01-2006"),
-		"Cancelable":  false,
-		"Amount":      "1.00 EUR",
-		"Method":      "paypal",
-		"Description": "testing KV",
-	}
+	w := map[string]interface{}{"AMOUNT": "1.00 EUR", "APP FEE": "none", "AUTHORIZED AT": "----------", "CANCELABLE": false, "CANCELED AT": "----------", "CAPTURED": "--- ---", "COUNTRY": "", "CREATED AT": "04-11-2020", "CUSTOMER ID": "", "DESCRIPTION": "testing KV", "EXPIRES": "06-11-2020", "FAILED AT": "----------", "ID": "tr_test", "LOCALE": "", "MANDATE ID": "", "METHOD": "paypal", "MODE": "test", "ORDER ID": "", "PAID AT": "----------", "REDIRECT": "", "REFUNDED": "--- ---", "REMAINING": "--- ---", "RESOURCE": "", "SEQUENCE": "", "SETTLEMENT": "--- ---", "SETTLEMENT ID": "", "STATUS": "paid", "SUBSCRIPTION ID": "", "WEBHOOK": ""}
 
-	w1 := map[string]interface{}{
-		"ID":          "tr_test_2",
-		"Mode":        mollie.TestMode,
-		"Status":      "expired",
-		"Created":     n.Format("02-01-2006"),
-		"Expires":     n.AddDate(0, 0, 2).Format("02-01-2006"),
-		"Cancelable":  false,
-		"Amount":      "2.00 USD",
-		"Method":      "banktransfer",
-		"Description": "testing KV list payments",
-	}
+	w1 := map[string]interface{}{"AMOUNT": "2.00 USD", "APP FEE": "none", "AUTHORIZED AT": "----------", "CANCELABLE": false, "CANCELED AT": "----------", "CAPTURED": "--- ---", "COUNTRY": "", "CREATED AT": "04-11-2020", "CUSTOMER ID": "", "DESCRIPTION": "testing KV list payments", "EXPIRES": "06-11-2020", "FAILED AT": "----------", "ID": "tr_test_2", "LOCALE": "", "MANDATE ID": "", "METHOD": "banktransfer", "MODE": "test", "ORDER ID": "", "PAID AT": "----------", "REDIRECT": "", "REFUNDED": "--- ---", "REMAINING": "--- ---", "RESOURCE": "", "SEQUENCE": "", "SETTLEMENT": "--- ---", "SETTLEMENT ID": "", "STATUS": "expired", "SUBSCRIPTION ID": "", "WEBHOOK": ""}
 
 	want := []map[string]interface{}{}
 	want = append(want, w, w1)

--- a/commands/payments.go
+++ b/commands/payments.go
@@ -130,7 +130,7 @@ ordered from newest to oldest. The results are paginated.`,
 			Aliases:   []string{"new", "start"},
 			Example:   "mollie payments create --amount-value=200.00 --amount-currency=USD --redirect-to=https://victoravelar.com --description='custom example payment'",
 		},
-		noCols,
+		paymentsCols,
 	)
 
 	command.AddFlag(cpp, command.FlagConfig{
@@ -201,7 +201,7 @@ ordered from newest to oldest. The results are paginated.`,
 			LongDesc:  `There are also payment method specific parameters available, check the docs, please.`,
 			Execute:   RunUpdatePayment,
 		},
-		noCols,
+		paymentsCols,
 	)
 
 	command.AddFlag(up, command.FlagConfig{

--- a/commands/payments.go
+++ b/commands/payments.go
@@ -445,7 +445,7 @@ func RunUpdatePayment(cmd *cobra.Command, args []string) {
 
 	disp := displayers.MolliePayment{Payment: &p}
 
-	err = command.Display(paymentsCols, disp.KV())
+	err = command.Display(getPaymentCols(cmd), disp.KV())
 	if err != nil {
 		logger.Fatal(err)
 	}

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -53,6 +53,16 @@ func Builder(parent *Command, config Config, cols []string) *Command {
 		parent.AddCommand(c)
 	}
 
+	AddFlag(
+		c,
+		FlagConfig{
+			Name:       "fields",
+			Persistent: true,
+			Shorthand:  "f",
+			Usage:      "select displayable fields to filter the console output",
+		},
+	)
+
 	return c
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adding a flag that allows to either display the full resource (as retrieved from the API) or filter the desired fields (passing them as a comma separated list).

It gives the end user the possibility to decide which elements of the response payload need to be displayed instead of making an arbitrary decision and not allowing any change without a PR.

## Motivation and context

It makes the CLI tool suitable for different use cases and gives users the freedom to customize the content and order of the result displayed in the terminal.

## How has this been tested?

Several unit test added for changes performed in the code, integration testing is still missing.

## Screenshots (if appropriate)
Before:

![image](https://user-images.githubusercontent.com/7926849/102011445-6797bc80-3d44-11eb-98a9-df303e01fb9b.png)

After:
**Filtered**
![image](https://user-images.githubusercontent.com/7926849/102011537-1b00b100-3d45-11eb-9bee-70c0b71d3b86.png)


**Not filtered** *the screenshot won't be visible enough*
```bash
RESOURCE    ID               MODE    STATUS     CANCELABLE    AMOUNT        METHOD          DESCRIPTION                     SEQUENCE    REMAINING     REFUNDED     CAPTURED    SETTLEMENT    APP FEE    CREATED AT    AUTHORIZED AT    EXPIRES       PAID AT       FAILED AT     CANCELED AT    CUSTOMER ID    SETTLEMENT ID    MANDATE ID    SUBSCRIPTION ID    ORDER ID    REDIRECT                                   WEBHOOK    LOCALE    COUNTRY
payment     tr_72cMJRBnmG    test    paid       false         199.00 EUR    ideal           ideal for refund cancelation    oneoff      109.00 EUR    90.00 EUR    --- ---     199.00 EUR    none       10-11-2020    ----------       ----------    10-11-2020    ----------    ----------                                                                                  https://victoravelar.com                              en_DE     DE
payment     tr_muKvgmhUme    test    paid       false         231.00 USD    creditcard      payment for refund              oneoff      200.00 USD    31.00 USD    --- ---     189.71 EUR    none       10-11-2020    ----------       ----------    10-11-2020    ----------    ----------                                                                                  https://victoravelar.com                              en_DE     DE
payment     tr_C2E3hSgPG3    test    expired    false         200.00 USD    none            custom example payment          oneoff      --- ---       --- ---      --- ---     --- ---       none       02-11-2020    ----------       ----------    ----------    ----------    ----------                                                                                  https://victoravelar.com
payment     tr_JuBwvs2bJB    test    paid       false         50.00 EUR     banktransfer    test payment with more data     oneoff      50.00 EUR     0.00 EUR     --- ---     50.00 EUR     none       27-10-2020    ----------       ----------    10-11-2020    ----------    ----------                                                                                  https://victoravelar.com                              en_US     DE
payment     tr_2pdWxPHExP    test    expired    false         50.00 EUR     banktransfer    test payment with more data     oneoff      --- ---       --- ---      --- ---     --- ---       none       27-10-2020    ----------       ----------    ----------    ----------    ----------                                                                                  https://victoravelar.com                              es_ES     DE
payment     tr_gmd6uJWKbz    test    expired    false         50.00 EUR     none            test payment with more data     oneoff      --- ---       --- ---      --- ---     --- ---       none       27-10-2020    ----------       ----------    ----------    ----------    ----------                                                                                  https://victoravelar.com                              de_DE
payment     tr_FpbEE8v5sP    test    expired    false         100.00 EUR    creditcard      test curl with redirect url     oneoff      --- ---       --- ---      --- ---     --- ---       none       25-10-2020    ----------       ----------    ----------    ----------    ----------                                                                                  https://victoravelar.com/test-curl-desc               fr_FR
payment     tr_xuDh8UVdem    test    expired    false         100.00 EUR    paypal          Demo payment from the CLI       oneoff      --- ---       --- ---      --- ---     --- ---       none       25-10-2020    ----------       ----------    ----------    ----------    ----------                                                                                  https://victoravelar.com
```
## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our continuous integration server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
