### PR TITLE
Profiles filterable implementation

### DIFF
--- a/commands/displayers/profile.go
+++ b/commands/displayers/profile.go
@@ -12,15 +12,7 @@ func (mpl *MollieProfileList) KV() []map[string]interface{} {
 	var out []map[string]interface{}
 
 	for _, r := range mpl.Embedded.Profiles {
-		x := map[string]interface{}{
-			"ID":      r.ID,
-			"Name":    r.Name,
-			"Website": r.Website,
-			"Phone":   r.Phone,
-			"Status":  r.Status,
-			"Mode":    r.Mode,
-			"Since":   r.CreatedAt.Format("02-01-2006"),
-		}
+		x := buildXProfile(r)
 
 		out = append(out, x)
 	}
@@ -37,17 +29,25 @@ type MollieProfile struct {
 func (mp *MollieProfile) KV() []map[string]interface{} {
 	var out []map[string]interface{}
 
-	x := map[string]interface{}{
-		"ID":      mp.Profile.ID,
-		"Name":    mp.Profile.Name,
-		"Website": mp.Profile.Website,
-		"Phone":   mp.Profile.Phone,
-		"Status":  mp.Profile.Status,
-		"Mode":    mp.Profile.Mode,
-		"Since":   mp.CreatedAt.Format("02-01-2006"),
-	}
+	x := buildXProfile(mp.Profile)
 
 	out = append(out, x)
 
 	return out
+}
+
+func buildXProfile(p *mollie.Profile) map[string]interface{} {
+	return map[string]interface{}{
+		"RESOURCE":      p.Resource,
+		"ID":            p.ID,
+		"MODE":          fallbackSafeMode(p.Mode),
+		"NAME":          p.Name,
+		"WEBSITE":       p.Website,
+		"EMAIL":         p.Email,
+		"PHONE":         p.Phone,
+		"CATEGORY_CODE": p.CategoryCode,
+		"STATUS":        p.Status,
+		"REVIEW":        p.Review.Status,
+		"CREATED_AT":    fallbackSafeDate(p.CreatedAt),
+	}
 }

--- a/commands/displayers/profile_test.go
+++ b/commands/displayers/profile_test.go
@@ -81,15 +81,19 @@ func TestMollieProfileList_KV(t *testing.T) {
 }
 
 func expectProfileSlice(pfs ...*mollie.Profile) (out []map[string]interface{}) {
-	for _, r := range pfs {
+	for _, p := range pfs {
 		x := map[string]interface{}{
-			"ID":      r.ID,
-			"Name":    r.Name,
-			"Website": r.Website,
-			"Phone":   r.Phone,
-			"Status":  r.Status,
-			"Mode":    r.Mode,
-			"Since":   r.CreatedAt.Format("02-01-2006"),
+			"RESOURCE":      p.Resource,
+			"ID":            p.ID,
+			"MODE":          fallbackSafeMode(p.Mode),
+			"NAME":          p.Name,
+			"WEBSITE":       p.Website,
+			"EMAIL":         p.Email,
+			"PHONE":         p.Phone,
+			"CATEGORY_CODE": p.CategoryCode,
+			"STATUS":        p.Status,
+			"REVIEW":        p.Review.Status,
+			"CREATED_AT":    fallbackSafeDate(p.CreatedAt),
 		}
 
 		out = append(out, x)

--- a/commands/profiles.go
+++ b/commands/profiles.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"strings"
+
 	"github.com/spf13/cobra"
 
 	"github.com/VictorAvelar/mollie-cli/commands/displayers"
@@ -9,13 +11,17 @@ import (
 
 var (
 	profileCols = []string{
+		"RESOURCE",
 		"ID",
-		"Name",
-		"Website",
-		"Phone",
-		"Status",
-		"Mode",
-		"Since",
+		"MODE",
+		"NAME",
+		"WEBSITE",
+		"EMAIL",
+		"PHONE",
+		"CATEGORY_CODE",
+		"STATUS",
+		"REVIEW",
+		"CREATED_AT",
 	}
 )
 
@@ -75,7 +81,7 @@ func RunCurrentProfile(cmd *cobra.Command, args []string) {
 
 	mp := displayers.MollieProfile{Profile: p}
 
-	err = command.Display(profileCols, mp.KV())
+	err = command.Display(getProfileCols(cmd), mp.KV())
 	if err != nil {
 		logger.Error(err)
 	}
@@ -100,8 +106,30 @@ func RunGetProfile(cmd *cobra.Command, args []string) {
 
 	mp := displayers.MollieProfile{Profile: p}
 
-	err = command.Display(profileCols, mp.KV())
+	err = command.Display(getProfileCols(cmd), mp.KV())
 	if err != nil {
 		logger.Error(err)
 	}
+}
+
+func getProfileCols(cmd *cobra.Command) []string {
+	var cols []string
+	{
+		cls := ParseStringFromFlags(cmd, FieldsArg)
+
+		if cls != "" {
+			cols = strings.Split(cls, ",")
+			if verbose {
+				PrintNonemptyFlagValue(FieldsArg, cls)
+			}
+		} else {
+			cols = profileCols
+			if verbose {
+				logger.Info("returning all fields")
+			}
+		}
+
+	}
+
+	return cols
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Filterable fields implementation for the profiles resource.

## Motivation and context

It makes the CLI tool suitable for different use cases and gives users the freedom to customize the content and order of the result displayed in the terminal.

## How has this been tested?

Existing unit tests passing.

## Example

**Current**

Command

```bash
mollie profiles current
```
Returns
```bash
ID                Name                          Website                     Phone               Status        Mode    Since
pfl_TrnugSbWUb    Victor xxxx Avelar xxxxx    https://victoravelar.com    +524917640000000    unverified    live    11-10-2020
```
**NEW** *default*

Command

```bash
mollie profiles current
```
Returns

```bash
RESOURCE    ID                MODE    NAME                          WEBSITE                     EMAIL                  PHONE               CATEGORY_CODE    STATUS        REVIEW     CREATED_AT
profile     pfl_TrnugSbWUb    live    Victor xxxx Avelar xxxxxxx    https://victoravelar.com    xxxxxxxx@gmail.com    +5249176400000000   8398             unverified    pending    11-10-2020
```
**NEW** *filtered*

Command

```bash
mollie profiles current -f ID,STATUS,WEBSITE
```

Returns

```bash
ID                STATUS        WEBSITE
pfl_TrnugSbWUb    unverified    https://victoravelar.com
```


## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our continuous integration server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
