### PR TITLE
Refunds filterable implementation

### DIFF
--- a/commands/displayers/refunds.go
+++ b/commands/displayers/refunds.go
@@ -12,16 +12,7 @@ func (mrl *MollieRefundList) KV() []map[string]interface{} {
 	var out []map[string]interface{}
 
 	for _, r := range mrl.Embedded.Refunds {
-		x := map[string]interface{}{
-			"ID":          r.ID,
-			"Payment":     r.PaymentID,
-			"Order":       r.OrderID,
-			"Settlement":  r.SettlementID,
-			"Amount":      stringCombinator(" ", r.Amount.Value, r.Amount.Currency),
-			"Status":      r.Status,
-			"Description": r.Description,
-			"Created at":  r.CreatedAt.Format("02-01-2006"),
-		}
+		x := buildXRefund(r)
 
 		out = append(out, x)
 	}
@@ -38,18 +29,25 @@ type MollieRefund struct {
 func (mr *MollieRefund) KV() []map[string]interface{} {
 	var out []map[string]interface{}
 
-	x := map[string]interface{}{
-		"ID":          mr.ID,
-		"Payment":     mr.PaymentID,
-		"Order":       mr.OrderID,
-		"Settlement":  mr.SettlementID,
-		"Amount":      stringCombinator(" ", mr.Amount.Value, mr.Amount.Currency),
-		"Status":      mr.Status,
-		"Description": mr.Description,
-		"Created at":  mr.CreatedAt.Format("02-01-2006"),
-	}
+	x := buildXRefund(mr.Refund)
 
 	out = append(out, x)
 
 	return out
+}
+
+func buildXRefund(r *mollie.Refund) map[string]interface{} {
+	return map[string]interface{}{
+		"RESOURCE":          r.Resource,
+		"ID":                r.ID,
+		"AMOUNT":            fallbackSafeAmount(r.Amount),
+		"SETTLEMENT_ID":     r.SettlementID,
+		"SETTLEMENT_AMOUNT": fallbackSafeAmount(r.SettlementAmount),
+		"DESCRIPTION":       r.Description,
+		"METADATA":          r.Metadata,
+		"STATUS":            r.Status,
+		"PAYMENT_ID":        r.PaymentID,
+		"ORDER_ID":          r.OrderID,
+		"CREATED_AT":        fallbackSafeDate(r.CreatedAt),
+	}
 }

--- a/commands/displayers/refunds_test.go
+++ b/commands/displayers/refunds_test.go
@@ -92,14 +92,17 @@ func TestMollieRefundList_KV(t *testing.T) {
 func expectedRefundSlice(refs ...*mollie.Refund) (out []map[string]interface{}) {
 	for _, r := range refs {
 		x := map[string]interface{}{
-			"ID":          r.ID,
-			"Payment":     r.PaymentID,
-			"Order":       r.OrderID,
-			"Settlement":  r.SettlementID,
-			"Amount":      stringCombinator(" ", r.Amount.Value, r.Amount.Currency),
-			"Status":      r.Status,
-			"Description": r.Description,
-			"Created at":  r.CreatedAt.Format("02-01-2006"),
+			"RESOURCE":          r.Resource,
+			"ID":                r.ID,
+			"AMOUNT":            fallbackSafeAmount(r.Amount),
+			"SETTLEMENT_ID":     r.SettlementID,
+			"SETTLEMENT_AMOUNT": fallbackSafeAmount(r.SettlementAmount),
+			"DESCRIPTION":       r.Description,
+			"METADATA":          r.Metadata,
+			"STATUS":            r.Status,
+			"PAYMENT_ID":        r.PaymentID,
+			"ORDER_ID":          r.OrderID,
+			"CREATED_AT":        fallbackSafeDate(r.CreatedAt),
 		}
 
 		out = append(out, x)

--- a/commands/refunds.go
+++ b/commands/refunds.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"os"
+	"strings"
 
 	"github.com/VictorAvelar/mollie-api-go/v2/mollie"
 	"github.com/VictorAvelar/mollie-cli/commands/displayers"
@@ -11,14 +12,17 @@ import (
 
 var (
 	refundsCols = []string{
+		"RESOURCE",
 		"ID",
-		"Payment",
-		"Order",
-		"Settlement",
-		"Amount",
-		"Status",
-		"Description",
-		"Created at",
+		"AMOUNT",
+		"SETTLEMENT_ID",
+		"SETTLEMENT_AMOUNT",
+		"DESCRIPTION",
+		"METADATA",
+		"STATUS",
+		"PAYMENT_ID",
+		"ORDER_ID",
+		"CREATED_AT",
 	}
 )
 
@@ -198,7 +202,7 @@ func RunListRefunds(cmd *cobra.Command, args []string) {
 
 	disp := displayers.MollieRefundList{RefundList: refunds}
 
-	err = command.Display(refundsCols, disp.KV())
+	err = command.Display(getRefundsCols(cmd), disp.KV())
 	if err != nil {
 		logger.Fatal(err)
 	}
@@ -225,7 +229,7 @@ func RunGetRefund(cmd *cobra.Command, args []string) {
 		Refund: &r,
 	}
 
-	err = command.Display(refundsCols, disp.KV())
+	err = command.Display(getRefundsCols(cmd), disp.KV())
 	if err != nil {
 		logger.Fatal(err)
 	}
@@ -266,7 +270,7 @@ func RunCreateRefund(cmd *cobra.Command, args []string) {
 
 	disp := displayers.MollieRefund{Refund: &rs}
 
-	err = command.Display(refundsCols, disp.KV())
+	err = command.Display(getRefundsCols(cmd), disp.KV())
 	if err != nil {
 		logger.Fatal(err)
 	}
@@ -299,4 +303,26 @@ func getRefundList(opts *mollie.ListRefundOptions, payment string) (*mollie.Refu
 	}
 
 	return API.Refunds.ListRefund(opts)
+}
+
+func getRefundsCols(cmd *cobra.Command) []string {
+	var cols []string
+	{
+		cls := ParseStringFromFlags(cmd, FieldsArg)
+
+		if cls != "" {
+			cols = strings.Split(cls, ",")
+			if verbose {
+				PrintNonemptyFlagValue(FieldsArg, cls)
+			}
+		} else {
+			cols = refundsCols
+			if verbose {
+				logger.Info("returning all fields")
+			}
+		}
+
+	}
+
+	return cols
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Filterable fields implementation for the refunds resource

## Motivation and context

It makes the CLI tool suitable for different use cases and gives users the freedom to customize the content and order of the result displayed in the terminal.

## How has this been tested?

Existing unit tests fixed.

##  Examples

Command

```bash
mollie refunds list
```

**Current**

Returns

```bash
ID               Payment          Order    Settlement    Amount       Status      Description                     Created at
re_6E45vptKMK    tr_72cMJRBnmG                           90.00 EUR    refunded    ideal for refund cancelation    10-11-2020
re_9JqpEe9AmB    tr_muKvgmhUme                           31.00 USD    refunded    first payment refund            10-11-2020
```

**NEW**

Returns *default*

```bash
RESOURCE    ID               AMOUNT       SETTLEMENT_ID    SETTLEMENT_AMOUNT    DESCRIPTION                     METADATA                                           STATUS      PAYMENT_ID       ORDER_ID    CREATED_AT
refund      re_6E45vptKMK    90.00 EUR                     -90.00 EUR           ideal for refund cancelation                                                       refunded    tr_72cMJRBnmG                10-11-2020
refund      re_9JqpEe9AmB    31.00 USD                     -27.04 EUR           first payment refund            Need to charge 200.00 USD instead of 231.00 USD    refunded    tr_muKvgmhUme                10-11-2020
```
**Filtered**

Command

```bash
mollie refunds list -f ID,SETTLEMENT_AMOUNT,DESCRIPTION
```

Returns

```bash
ID               SETTLEMENT_AMOUNT    DESCRIPTION
re_6E45vptKMK    -90.00 EUR           ideal for refund cancelation
re_9JqpEe9AmB    -27.04 EUR           first payment refund
```

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our continuous integration server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
